### PR TITLE
Add sample API connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # PG
+
+This repository includes a simple Python module for connecting to an API.
+
+## Usage
+
+1. Install the required dependency:
+   ```bash
+   pip install requests
+   ```
+2. Run the connector script:
+   ```bash
+   python api_connector.py
+   ```
+   By default it requests `https://api.example.com/data`. Update the URL in
+   `api_connector.py` to target your desired API endpoint.

--- a/api_connector.py
+++ b/api_connector.py
@@ -1,0 +1,23 @@
+import requests
+
+class APIConnector:
+    """Simple API connector that performs GET requests."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip('/')
+
+    def get(self, endpoint: str, **kwargs):
+        """Send a GET request to the specified endpoint and return the JSON response."""
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        response = requests.get(url, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+if __name__ == "__main__":
+    # Example usage; replace 'https://api.example.com' and '/data' as needed
+    connector = APIConnector("https://api.example.com")
+    try:
+        data = connector.get("/data")
+        print(data)
+    except requests.exceptions.RequestException as exc:
+        print(f"API request failed: {exc}")


### PR DESCRIPTION
## Summary
- implement simple `APIConnector` using `requests`
- document usage and dependencies

## Testing
- `python -m py_compile api_connector.py`
- `python api_connector.py` *(fails: `ModuleNotFoundError: No module named 'requests'`)*

------
https://chatgpt.com/codex/tasks/task_e_685b992c28dc83339c5780532249384e